### PR TITLE
Whitelist files to include in download

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tap": "~0.4.0"
   },
   "files": [
-    "index.js"
+    "alter.js"
   ],
   "author": "Olov Lassus <olov.lassus@gmail.com>",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "devDependencies": {
     "tap": "~0.4.0"
   },
+  "files": [
+    "index.js"
+  ],
   "author": "Olov Lassus <olov.lassus@gmail.com>",
   "license": "MIT"
 }


### PR DESCRIPTION
Currently, an `npm install alter` will install alter **and** the test files. These are unecessary bloat, so by adding the `files` attribute in the `package.json` file, npm will only download `alter.js`, `README.md`, `LICENSE`, and `package.json`
